### PR TITLE
Handles Content-Type and Accept headers

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -208,7 +208,16 @@ REST_FRAMEWORK = {
     # Active OAuth2 authentication.
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.OAuth2Authentication',
-    )
+    ),
+    'DEFAULT_PARSER_CLASSES': (
+        'rest_framework.parsers.JSONParser',
+        'rest_framework.parsers.XMLParser',
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.XMLRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ),
 }
 
 REST_FRAMEWORK_EXTENSIONS = {


### PR DESCRIPTION
L'API peut maintenant renvoyer (ou accepter) les résultats en JSON ou en XML.