### PR TITLE
Nettoyage galerie : correction affichage des utilisateurs d'une galerie

### DIFF
--- a/templates/gallery/gallery/details.html
+++ b/templates/gallery/gallery/details.html
@@ -34,7 +34,7 @@
     <div class="authors">
         <span class="authors-label">{% trans "Galerie partagée avec" %} : </span>
         <ul>
-            {% for u in gallery.get_users %}
+            {% for u in gallery.get_linked_users %}
                 {% captureas info %}
                     {% if u.mode == 'R' %}
                         {% trans "Lecture" %}


### PR DESCRIPTION
Correction, du bug trouvé par Eskimon.

Par contre, souci avec la modale d'ajout d'un membre. Et il semble que les scripts gulp de cette branche ne sont plus à jour. Du coup, j'arrive pas à mettre le front à jour pour voir s'il s'agit bien d'un bug ou si c'est juste mon environnement qui a un souci.

Possible de faire un ptit rebase ?