### PR TITLE
corrige les erreurs de tutorialv2 et munin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ coverage==4.0.1
 # TODO : django-crispy-forms==1.5.2
 https://github.com/gustavi/django-crispy-forms/archive/dev.zip
 django-haystack==2.4.1
-django-model-utils==2.3.1
+django-model-utils==2.4
 django-munin==0.2.0
 python-memcached==1.54
 lxml==3.4.4

--- a/templates/tutorialv2/includes/reaction_message.part.html
+++ b/templates/tutorialv2/includes/reaction_message.part.html
@@ -181,7 +181,7 @@
                 </div>
             {% endif %}
 
-            {% if message.is_visible = False %}
+            {% if not message.is_visible %}
                 <p class="message-hidden">
                     {% trans "Masqué par" %} {{ message.editor }}
                     {% if message.text_hidden %}
@@ -244,7 +244,7 @@
                     <div class="message-karma">
                         {% if user.is_authenticated and helpful_link and not is_author %}
                             {% if message.author != user or perms_change %}
-                                {% if topic.author = user or perms_change %}
+                                {% if topic.author == user or perms_change %}
                                     <form action="{{ helpful_link }}" method="post">
                                         {% csrf_token %}
                                         <button

--- a/zds/munin/urls.py
+++ b/zds/munin/urls.py
@@ -6,9 +6,9 @@ from zds.munin.views import total_topics, total_posts, total_mps, total_tutorial
 
 
 urlpatterns = [
-    url(r'^total_topics/$', total_topics),
-    url(r'^total_posts/$', total_posts),
-    url(r'^total_mps/$', total_mps),
-    url(r'^total_tutorials/$', total_tutorials),
-    url(r'^total_articles/$', total_articles),
+    url(r'^total_topics/$', total_topics, name="total_topics"),
+    url(r'^total_posts/$', total_posts, name="total_posts"),
+    url(r'^total_mps/$', total_mps, name="total_mp"),
+    url(r'^total_tutorials/$', total_tutorials, name="total_tutorial"),
+    url(r'^total_articles/$', total_articles, name="total_articles"),
 ]

--- a/zds/tutorialv2/models/models_database.py
+++ b/zds/tutorialv2/models/models_database.py
@@ -426,7 +426,7 @@ class PublishableContent(models.Model):
                 read = ContentRead.objects\
                     .select_related('note')\
                     .select_related('note__related_content')\
-                    .select_related('related_content__public_version')\
+                    .select_related('note__related_content__public_version')\
                     .filter(content=self, user__pk=user.pk)\
                     .latest('note__pubdate')
                 if read is not None and read.note:  # one case can show a read without note : the author has just

--- a/zds/tutorialv2/views/views_contents.py
+++ b/zds/tutorialv2/views/views_contents.py
@@ -70,7 +70,7 @@ class CreateContent(LoggedWithReadWriteHability, FormView):
     content = None
     created_content_type = "TUTORIAL"
 
-    def get_form(self, form_class):
+    def get_form(self, form_class=ContentForm):
         form = super(CreateContent, self).get_form(form_class)
         form.initial["type"] = self.created_content_type
         form.initial['licence'] = Licence.objects.get(pk=settings.ZDS_APP['content']['default_licence_pk'])
@@ -1030,7 +1030,7 @@ class EditContainer(LoggedWithReadWriteHability, SingleContentFormViewMixin):
 
     def get_context_data(self, **kwargs):
         context = super(EditContainer, self).get_context_data(**kwargs)
-        form = kwargs.pop('form', None)
+        form = kwargs.pop('form', self.get_form())
         context['container'] = form.initial['container']
         context['gallery'] = self.object.gallery
 
@@ -1128,7 +1128,7 @@ class EditExtract(LoggedWithReadWriteHability, SingleContentFormViewMixin):
 
     def get_context_data(self, **kwargs):
         context = super(EditExtract, self).get_context_data(**kwargs)
-        form = kwargs.pop('form', None)
+        form = kwargs.pop('form', self.get_form())
         context['extract'] = form.initial['extract']
         context['gallery'] = self.object.gallery
 


### PR DESCRIPTION
j'ai corrigé quelques erreurs et avertissements dans la migration vers django 1.9 du module tutorialv2.

La seule chose qui reste en erreur est le test "migrate to zep12" mais ce dernier doit avoir été supprimé depuis longtemps (il te faut faire un rebase sur le dépôt principal).
A partir de là ça devrait aller.